### PR TITLE
Update battery to give info and percentage.

### DIFF
--- a/Firmware/ow10000-demo.ino
+++ b/Firmware/ow10000-demo.ino
@@ -263,7 +263,7 @@ void loop() {
 
 	if(badge.buttonD_debounce()){
 		badge.clear();
-		text_temp = String(badge.battery_level());
+		text_temp =  "Battery: " + String(badge.battery_level())  + "%   ";
 		scrollingText.setTextString(text_temp);
 	}
 	

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,9 @@ Standard Operation:
 - Main Function
     - Button 1 (Top Button): Display Scrolling Text 1
     - Button 2 (Bottom Button): Display Scrolling Text 2
-    - Hold Both Buttons: Enter Menu Mode
+    - Down button: Show battery percentage
+    - Hold Right Button: Fast scrolling
+    - Hold Both Buttons (1 and 2): Enter Menu Mode
 - Menu
     - Select an option using the Up and Down, Press button 1 to Select
 	- Current Menu options


### PR DESCRIPTION
The default battery button just repeated the battery number over and over again, like 100100100100100...
Now it tells the user the percentage.
